### PR TITLE
Fix Expo entry

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "platforms": ["ios", "android"],
-    "sdkVersion": "49.0.0",
+    "sdkVersion": "53.0.0",
     "jsEngine": "hermes",
     "updates": {
       "fallbackToCacheTimeout": 0

--- a/firebase.js
+++ b/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "valdo-app",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -13,10 +13,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "expo": "^49.0.0",
-    "expo-status-bar": "^1.6.0",
+    "expo": "^53.0.0",
+    "expo-status-bar": "^1.9.0",
     "firebase": "^11.9.1",
     "react": "^18.2.0",
-    "react-native": "0.72.4"
+    "react-native": "0.73.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Expo to use its default entry file
- create `index.js` file to register `App`
- add missing `getFirestore` import in `firebase.js`
- upgrade the Expo SDK from 49 to 53 for compatibility with current Expo Go

## Testing
- `npm --version`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e3d8d7a68832da9f0996b46beb137